### PR TITLE
3 extract process article content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "bias_lens",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@mozilla/readability": "^0.6.0"
+      },
       "devDependencies": {
         "copy-webpack-plugin": "^13.0.0",
         "webpack": "^5.99.5",
@@ -86,6 +89,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/eslint": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "copy-webpack-plugin": "^13.0.0",
     "webpack": "^5.99.5",
     "webpack-cli": "^6.0.1"
+  },
+  "dependencies": {
+    "@mozilla/readability": "^0.6.0"
   }
 }

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -12,8 +12,8 @@ let { Readability } = require("@mozilla/readability");
 function scrapeArticle() {
   let _document = document.cloneNode(true);
   let { title, textContent, siteName } = new Readability(_document).parse();
-  let URL = window.location.href;
-  let data = { url: URL, title, textContent, siteName };
+  let url = window.location.href;
+  let data = { url, title, textContent, siteName };
 
   // add future site specific parsing here
   switch (data.siteName) {

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -2,12 +2,50 @@
 
 let { Readability } = require("@mozilla/readability");
 
+/**
+ * ============================================================================
+ * SCRAPING LOGIC
+ * ============================================================================
+ */
+
 // we get the data is relevant to our API
-let { title, textContent, siteName } = new Readability(document).parse();
-let URL = window.location.href;
-let data = { url: URL, title, textContent, siteName };
+function scrapeArticle() {
+  let _document = document.cloneNode(true);
+  let { title, textContent, siteName } = new Readability(_document).parse();
+  let URL = window.location.href;
+  let data = { url: URL, title, textContent, siteName };
+
+  // add future site specific parsing here
+  switch (data.siteName) {
+    case "RAPPLER":
+      data.textContent = parseRappler(data.textContent);
+      break;
+    default:
+      break;
+  }
+
+  return data;
+}
+
+/**
+ * ============================================================================
+ * SITE SPECIFIC PARSING
+ * ============================================================================
+ */
+
+function parseRappler(textContent) {
+  let pattern = /.*? – (.*) –.*/s;
+  return textContent.replace(pattern, "$1");
+}
+
+/**
+ * ============================================================================
+ * DEBUGGING CODE
+ * ============================================================================
+ */
 
 // we stringify the JSON for portability
 let text_output = JSON.stringify(data, null, 2);
 
+/* TODO: Remove this line for production */
 console.log(text_output);

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -44,6 +44,8 @@ function parseRappler(textContent) {
  * ============================================================================
  */
 
+let data = scrapeArticle();
+
 // we stringify the JSON for portability
 let text_output = JSON.stringify(data, null, 2);
 

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -1,1 +1,15 @@
 // Access the DOM (Scraping part)
+
+let { Readability } = require("@mozilla/readability");
+
+let _document = document.cloneNode(true);
+let { title, textContent, siteName } = new Readability(_document).parse();
+let URL = window.location.href;
+
+let text_output = JSON.stringify(
+  { url: URL, title, textContent, siteName },
+  null,
+  2,
+);
+
+console.log(text_output);

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -2,14 +2,12 @@
 
 let { Readability } = require("@mozilla/readability");
 
-let _document = document.cloneNode(true);
-let { title, textContent, siteName } = new Readability(_document).parse();
+// we get the data is relevant to our API
+let { title, textContent, siteName } = new Readability(document).parse();
 let URL = window.location.href;
+let data = { url: URL, title, textContent, siteName };
 
-let text_output = JSON.stringify(
-  { url: URL, title, textContent, siteName },
-  null,
-  2,
-);
+// we stringify the JSON for portability
+let text_output = JSON.stringify(data, null, 2);
 
 console.log(text_output);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 module.exports = {
   mode: "development",
+  devtool: "inline-source-map",
   entry: {
     background: path.resolve(__dirname, "./src/background.js"),
     content: path.resolve(__dirname, "./src/scripts/content.js"),


### PR DESCRIPTION
Added a site-specific parser for Rappler as an example `parseRappler()`.

Additional site-specific preprocessing can be added in their *own* feature pull requests.