### PR TITLE
Default route sidepanel

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -10,6 +10,18 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
 
   if (message.action === "bias-analysis") {
     handleBiasAnalysis(message.data, sendResponse);
+    await chrome.sidePanel.setOptions({
+      path: `sidepanel/sidepanel.html`,
+      enabled: true,
+    });
+
+    return true;
+  } else if (message.action === "default") {
+    await chrome.sidePanel.setOptions({
+      path: `sidepanel/sidepanel_default.html`,
+      enabled: true,
+    });
+
     return true;
   }
 
@@ -35,6 +47,7 @@ function parseData(data) {
   });
   return map;
 }
+
 async function handleBiasAnalysis(data, sendResponse) {
   try {
     const response = await fetch(`${serverUrl}/analyze-bias`, {
@@ -52,7 +65,10 @@ async function handleBiasAnalysis(data, sendResponse) {
     const res = await response.json();
     const result = parseData(res.biasAnalysis);
     // sendResponse({ action: "bias-analysis-result", data: result });
-    chrome.runtime.sendMessage({ action: "bias-analysis-result", data: result });
+    chrome.runtime.sendMessage({
+      action: "bias-analysis-result",
+      data: result,
+    });
   } catch (error) {
     sendResponse({ action: "bias-analysis-error", error: error.message });
   }

--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,11 @@
 const serverUrl = "https://bias-lens-server-9feb0545fef6.herokuapp.com";
 console.log("Background script running.");
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.sidePanel
+  .setPanelBehavior({ openPanelOnActionClick: true })
+  .catch((error) => console.error(error));
+
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
   console.log("Background script received:", message);
 
   if (message.action === "bias-analysis") {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,12 @@
   "name": "Bias Lens",
   "description": "A tool to analyze and visualize bias in text data.",
   "version": "1.0",
-  "permissions": ["scripting", "tabs", "activeTab", "sidePanel"],
+  "permissions": [
+    "scripting",
+    "tabs",
+    "activeTab",
+    "sidePanel"
+  ],
   "action": {
     "default_icon": {
       "16": "assets/images/icon16.png",
@@ -12,18 +17,17 @@
     }
   },
   "side_panel": {
-    "default_path": "sidepanel/sidepanel.html"
+    "default_path": "sidepanel/sidepanel_default.html"
   },
   "content_scripts": [
     {
       "matches": [
-        "https://www.rappler.com/*",
-        "https://*.inquirer.net/*",
-        "https://www.philstar.com/*",
-        "https://www.abs-cbn.com/*",
-        "https://www.gmanetwork.com/news/*"
+        "http://*/*",
+        "https://*/*"
       ],
-      "js": ["content.bundle.js"]
+      "js": [
+        "content.bundle.js"
+      ]
     }
   ],
   "background": {

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -27,6 +27,7 @@ function scrapeArticle() {
       data.textContent = parseInquirer(data.textContent);
       break;
     default:
+      data.textContent = undefined;
       break;
   }
 
@@ -58,8 +59,11 @@ function parseInquirer(textContent) {
 
 let articleData = scrapeArticle();
 
+let messageAction =
+  articleData.textContent != undefined ? "bias-analysis" : "default";
+
 chrome.runtime.sendMessage(
-  { action: "bias-analysis", data: articleData },
+  { action: messageAction, data: articleData },
   (response) => {
     if (chrome.runtime.lastError) {
       console.error("Error sending message to background script:", response);
@@ -72,5 +76,5 @@ chrome.runtime.sendMessage(
     } else {
       console.warn("Unknown response received:", response);
     }
-  }
+  },
 );


### PR DESCRIPTION
Execute content script on all pages, but send a `default` action to the listener whenever an unsupported (parser not defined in switch) page is loaded.